### PR TITLE
Fix function argument usage

### DIFF
--- a/src/me/xdrop/fuzzywuzzy/algorithms/DefaultStringProcessor.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/DefaultStringProcessor.java
@@ -23,7 +23,7 @@ public class DefaultStringProcessor implements StringProcessor {
         Matcher m = r.matcher(in);
 
         if(m.find()){
-            return m.replaceAll(" ");
+            return m.replaceAll(sub);
         } else {
             return in;
         }


### PR DESCRIPTION
The documentation states that the "sub" argument should define what substitute to replace with, instead a space was always used.