### PR TITLE
Bugfix weighted ratio

### DIFF
--- a/src/me/xdrop/fuzzywuzzy/algorithms/WeightedRatio.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/WeightedRatio.java
@@ -31,7 +31,7 @@ public class WeightedRatio extends BasicAlgorithm  {
         double partialScale = PARTIAL_SCALE;
 
         int base = ratio(s1, s2);
-        double lenRatio = (double) (Math.max(len1, len2) / Math.min(len1, len2));
+        double lenRatio = ( (double) Math.max(len1, len2) ) / Math.min(len1, len2);
 
         // if strings are similar length don't use partials
         if (lenRatio < 1.5) tryPartials = false;

--- a/src/me/xdrop/fuzzywuzzy/algorithms/WeightedRatio.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/WeightedRatio.java
@@ -31,7 +31,7 @@ public class WeightedRatio extends BasicAlgorithm  {
         double partialScale = PARTIAL_SCALE;
 
         int base = ratio(s1, s2);
-        double lenRatio = ( (double) Math.max(len1, len2) ) / Math.min(len1, len2);
+        double lenRatio = ((double) Math.max(len1, len2)) / Math.min(len1, len2);
 
         // if strings are similar length don't use partials
         if (lenRatio < 1.5) tryPartials = false;


### PR DESCRIPTION
I started using this library to convert NLP code from Python to Scala/Spark, however, I noticed some deviations in the outputs. I tracked down (part of) of the problem to:

original Python code from https://github.com/seatgeek/fuzzywuzzy/blob/master/fuzzywuzzy/fuzz.py
len_ratio = float(max(len(p1), len(p2))) / min(len(p1), len(p2))

Code in me.xdrop.fuzzywuzzy.algorithms.WeightedRatio.java:
double lenRatio = (double) (Math.max(len1, len2) / Math.min(len1, len2));

The Java code will first do the division and then the casting to double.