### PR TITLE
Deprecated StringProcessor

### DIFF
--- a/src/me/xdrop/fuzzywuzzy/FuzzySearch.java
+++ b/src/me/xdrop/fuzzywuzzy/FuzzySearch.java
@@ -37,13 +37,13 @@ public class FuzzySearch {
      *
      * @param s1              Input string
      * @param s2              Input string
-     * @param stringProcessor Functor which transforms strings before
+     * @param stringFunction Functor which transforms strings before
      *                        calculating the ratio
      * @return The simple ratio
      */
-    public static int ratio(String s1, String s2, StringProcessor stringProcessor) {
+    public static int ratio(String s1, String s2, ToStringFunction<String> stringFunction) {
 
-        return new SimpleRatio().apply(s1, s2, stringProcessor);
+        return new SimpleRatio().apply(s1, s2, stringFunction);
 
     }
 
@@ -69,13 +69,13 @@ public class FuzzySearch {
      *
      * @param s1              Input string
      * @param s2              Input string
-     * @param stringProcessor Functor which transforms strings before
+     * @param stringFunction Functor which transforms strings before
      *                        calculating the ratio
      * @return The partial ratio
      */
-    public static int partialRatio(String s1, String s2, StringProcessor stringProcessor) {
+    public static int partialRatio(String s1, String s2, ToStringFunction<String> stringFunction) {
 
-        return new PartialRatio().apply(s1, s2, stringProcessor);
+        return new PartialRatio().apply(s1, s2, stringFunction);
 
     }
 
@@ -101,13 +101,13 @@ public class FuzzySearch {
      *
      * @param s1              Input string
      * @param s2              Input string
-     * @param stringProcessor Functor which transforms strings before
+     * @param stringFunction Functor which transforms strings before
      *                        calculating the ratio
      * @return The partial ratio of the strings
      */
-    public static int tokenSortPartialRatio(String s1, String s2, StringProcessor stringProcessor) {
+    public static int tokenSortPartialRatio(String s1, String s2, ToStringFunction<String> stringFunction) {
 
-        return new TokenSort().apply(s1, s2, new PartialRatio(), stringProcessor);
+        return new TokenSort().apply(s1, s2, new PartialRatio(), stringFunction);
 
     }
 
@@ -133,13 +133,13 @@ public class FuzzySearch {
      *
      * @param s1              Input string
      * @param s2              Input string
-     * @param stringProcessor Functor which transforms strings before
+     * @param stringFunction Functor which transforms strings before
      *                        calculating the ratio
      * @return The full ratio of the strings
      */
-    public static int tokenSortRatio(String s1, String s2, StringProcessor stringProcessor) {
+    public static int tokenSortRatio(String s1, String s2, ToStringFunction<String> stringFunction) {
 
-        return new TokenSort().apply(s1, s2, new SimpleRatio(), stringProcessor);
+        return new TokenSort().apply(s1, s2, new SimpleRatio(), stringFunction);
 
     }
 
@@ -168,13 +168,13 @@ public class FuzzySearch {
      *
      * @param s1              Input string
      * @param s2              Input string
-     * @param stringProcessor Functor which transforms strings before
+     * @param stringFunction Functor which transforms strings before
      *                        calculating the ratio
      * @return The ratio of similarity
      */
-    public static int tokenSetRatio(String s1, String s2, StringProcessor stringProcessor) {
+    public static int tokenSetRatio(String s1, String s2, ToStringFunction<String> stringFunction) {
 
-        return new TokenSet().apply(s1, s2, new SimpleRatio(), stringProcessor);
+        return new TokenSet().apply(s1, s2, new SimpleRatio(), stringFunction);
 
     }
 
@@ -202,13 +202,13 @@ public class FuzzySearch {
      *
      * @param s1              Input string
      * @param s2              Input string
-     * @param stringProcessor Functor which transforms strings before
+     * @param stringFunction Functor which transforms strings before
      *                        calculating the ratio
      * @return The ratio of similarity
      */
-    public static int tokenSetPartialRatio(String s1, String s2, StringProcessor stringProcessor) {
+    public static int tokenSetPartialRatio(String s1, String s2, ToStringFunction<String> stringFunction) {
 
-        return new TokenSet().apply(s1, s2, new PartialRatio(), stringProcessor);
+        return new TokenSet().apply(s1, s2, new PartialRatio(), stringFunction);
 
     }
 
@@ -230,13 +230,13 @@ public class FuzzySearch {
      *
      * @param s1              Input string
      * @param s2              Input string
-     * @param stringProcessor Functor which transforms strings before
+     * @param stringFunction Functor which transforms strings before
      *                        calculating the ratio
      * @return The ratio of similarity
      */
-    public static int weightedRatio(String s1, String s2, StringProcessor stringProcessor) {
+    public static int weightedRatio(String s1, String s2, ToStringFunction<String> stringFunction) {
 
-        return new WeightedRatio().apply(s1, s2, stringProcessor);
+        return new WeightedRatio().apply(s1, s2, stringFunction);
 
     }
 

--- a/src/me/xdrop/fuzzywuzzy/Ratio.java
+++ b/src/me/xdrop/fuzzywuzzy/Ratio.java
@@ -22,6 +22,6 @@ public interface Ratio extends Applicable {
      * @param sp String processor to pre-process strings before calculating the ratio
      * @return Integer representing ratio of similarity
      */
-    int apply(String s1, String s2, StringProcessor sp);
+    int apply(String s1, String s2, ToStringFunction<String> sp);
 
 }

--- a/src/me/xdrop/fuzzywuzzy/StringProcessor.java
+++ b/src/me/xdrop/fuzzywuzzy/StringProcessor.java
@@ -2,15 +2,24 @@ package me.xdrop.fuzzywuzzy;
 
 /**
  * Transforms the input string
+ *
+ * @deprecated Use {@code ToStringFunction<String>} instead.
  */
-public interface StringProcessor {
-
+@Deprecated
+public abstract class StringProcessor implements ToStringFunction<String> {
+// now abstract class because JDK1.7 does not allow default methods in interfaces
     /**
      * Transforms the input string
      *
+     * @deprecated Use {@code ToStringFunction#apply(String)} instead.
      * @param in Input string
      * @return The processed string
      */
-    String process(String in);
+    @Deprecated
+    public abstract String process(String in);
 
+    @Override
+    public String apply(String item) {
+        return process(item);
+    }
 }

--- a/src/me/xdrop/fuzzywuzzy/algorithms/BasicAlgorithm.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/BasicAlgorithm.java
@@ -1,43 +1,43 @@
 package me.xdrop.fuzzywuzzy.algorithms;
 
 import me.xdrop.fuzzywuzzy.Applicable;
-import me.xdrop.fuzzywuzzy.StringProcessor;
+import me.xdrop.fuzzywuzzy.ToStringFunction;
 
 public abstract class BasicAlgorithm implements Applicable {
 
-    private StringProcessor stringProcessor;
+    private ToStringFunction<String> stringFunction;
 
     public BasicAlgorithm() {
-        this.stringProcessor = new DefaultStringProcessor();
+        this.stringFunction = new DefaultStringFunction();
     }
 
-    public BasicAlgorithm(StringProcessor stringProcessor) {
-        this.stringProcessor = stringProcessor;
+    public BasicAlgorithm(ToStringFunction<String> stringFunction) {
+        this.stringFunction = stringFunction;
     }
 
-    public abstract int apply(String s1, String s2, StringProcessor stringProcessor);
+    public abstract int apply(String s1, String s2, ToStringFunction<String> stringProcessor);
 
     public int apply(String s1, String s2){
 
-        return apply(s1, s2, this.stringProcessor);
+        return apply(s1, s2, this.stringFunction);
 
     }
 
-    public BasicAlgorithm with(StringProcessor stringProcessor){
-        setStringProcessor(stringProcessor);
+    public BasicAlgorithm with(ToStringFunction<String> stringFunction){
+        setStringFunction(stringFunction);
         return this;
     }
 
     public BasicAlgorithm noProcessor(){
-        this.stringProcessor = new NoProcess();
+        this.stringFunction = ToStringFunction.DEFAULT;
         return this;
     }
 
-    void setStringProcessor(StringProcessor stringProcessor){
-        this.stringProcessor = stringProcessor;
+    void setStringFunction(ToStringFunction<String> stringFunction){
+        this.stringFunction = stringFunction;
     }
 
-    public StringProcessor getStringProcessor() {
-        return stringProcessor;
+    public ToStringFunction<String> getStringFunction() {
+        return stringFunction;
     }
 }

--- a/src/me/xdrop/fuzzywuzzy/algorithms/DefaultStringFunction.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/DefaultStringFunction.java
@@ -2,13 +2,9 @@ package me.xdrop.fuzzywuzzy.algorithms;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import me.xdrop.fuzzywuzzy.StringProcessor;
+import me.xdrop.fuzzywuzzy.ToStringFunction;
 
-/**
- * @deprecated Use {@code DefaultStringFunction} instead.
- */
-@Deprecated
-public class DefaultStringProcessor extends StringProcessor {
+public class DefaultStringFunction implements ToStringFunction<String> {
 
     private final static String pattern = "[^\\p{Alnum}]";
     private final static Pattern r = compilePattern();
@@ -40,7 +36,7 @@ public class DefaultStringProcessor extends StringProcessor {
      * @return The processed string
      */
     @Override
-    public String process(String in) {
+    public String apply(String in) {
 
         in = subNonAlphaNumeric(in, " ");
         in = in.toLowerCase();

--- a/src/me/xdrop/fuzzywuzzy/algorithms/NoProcess.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/NoProcess.java
@@ -2,9 +2,14 @@ package me.xdrop.fuzzywuzzy.algorithms;
 
 import me.xdrop.fuzzywuzzy.StringProcessor;
 
-public class NoProcess implements StringProcessor {
+/**
+ * @deprecated Use {@code ToStringFunction#DEFAULT} instead.
+ */
+@Deprecated
+public class NoProcess extends StringProcessor {
 
     @Override
+    @Deprecated
     public String process(String in) {
         return in;
     }

--- a/src/me/xdrop/fuzzywuzzy/algorithms/RatioAlgorithm.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/RatioAlgorithm.java
@@ -1,7 +1,7 @@
 package me.xdrop.fuzzywuzzy.algorithms;
 
 import me.xdrop.fuzzywuzzy.Ratio;
-import me.xdrop.fuzzywuzzy.StringProcessor;
+import me.xdrop.fuzzywuzzy.ToStringFunction;
 import me.xdrop.fuzzywuzzy.ratios.SimpleRatio;
 
 public abstract class RatioAlgorithm extends BasicAlgorithm {
@@ -13,8 +13,8 @@ public abstract class RatioAlgorithm extends BasicAlgorithm {
         this.ratio = new SimpleRatio();
     }
 
-    public RatioAlgorithm(StringProcessor stringProcessor) {
-        super(stringProcessor);
+    public RatioAlgorithm(ToStringFunction<String> stringFunction) {
+        super(stringFunction);
     }
 
     public RatioAlgorithm(Ratio ratio) {
@@ -23,12 +23,12 @@ public abstract class RatioAlgorithm extends BasicAlgorithm {
     }
 
 
-    public RatioAlgorithm(StringProcessor stringProcessor, Ratio ratio) {
-        super(stringProcessor);
+    public RatioAlgorithm(ToStringFunction<String> stringFunction, Ratio ratio) {
+        super(stringFunction);
         this.ratio = ratio;
     }
 
-    public abstract int apply(String s1, String s2, Ratio ratio, StringProcessor stringProcessor);
+    public abstract int apply(String s1, String s2, Ratio ratio, ToStringFunction<String> stringFunction);
 
     public RatioAlgorithm with(Ratio ratio) {
         setRatio(ratio);
@@ -36,12 +36,12 @@ public abstract class RatioAlgorithm extends BasicAlgorithm {
     }
 
     public int apply(String s1, String s2, Ratio ratio) {
-        return apply(s1, s2, ratio, getStringProcessor());
+        return apply(s1, s2, ratio, getStringFunction());
     }
 
     @Override
-    public int apply(String s1, String s2, StringProcessor stringProcessor) {
-        return apply(s1, s2, getRatio(), stringProcessor);
+    public int apply(String s1, String s2, ToStringFunction<String> stringFunction) {
+        return apply(s1, s2, getRatio(), stringFunction);
     }
 
     public void setRatio(Ratio ratio) {

--- a/src/me/xdrop/fuzzywuzzy/algorithms/TokenSet.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/TokenSet.java
@@ -1,20 +1,20 @@
 package me.xdrop.fuzzywuzzy.algorithms;
 
 import me.xdrop.fuzzywuzzy.Ratio;
-import me.xdrop.fuzzywuzzy.StringProcessor;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import me.xdrop.fuzzywuzzy.ToStringFunction;
 
 public class TokenSet extends RatioAlgorithm {
 
     @Override
-    public int apply(String s1, String s2, Ratio ratio, StringProcessor stringProcessor) {
+    public int apply(String s1, String s2, Ratio ratio, ToStringFunction<String> stringFunction) {
 
-        s1 = stringProcessor.process(s1);
-        s2 = stringProcessor.process(s2);
+        s1 = stringFunction.apply(s1);
+        s2 = stringFunction.apply(s2);
 
         Set<String> tokens1 = Utils.tokenizeSet(s1);
         Set<String> tokens2 = Utils.tokenizeSet(s2);

--- a/src/me/xdrop/fuzzywuzzy/algorithms/TokenSort.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/TokenSort.java
@@ -1,26 +1,26 @@
 package me.xdrop.fuzzywuzzy.algorithms;
 
 import me.xdrop.fuzzywuzzy.Ratio;
-import me.xdrop.fuzzywuzzy.StringProcessor;
 
 import java.util.Arrays;
 import java.util.List;
+import me.xdrop.fuzzywuzzy.ToStringFunction;
 
 public class TokenSort extends RatioAlgorithm {
 
     @Override
-    public int apply(String s1, String s2, Ratio ratio, StringProcessor stringProcessor) {
+    public int apply(String s1, String s2, Ratio ratio, ToStringFunction<String> stringFunction) {
 
-        String sorted1 = processAndSort(s1, stringProcessor);
-        String sorted2 = processAndSort(s2, stringProcessor);
+        String sorted1 = processAndSort(s1, stringFunction);
+        String sorted2 = processAndSort(s2, stringFunction);
 
         return ratio.apply(sorted1, sorted2);
 
     }
 
-    private static String processAndSort(String in, StringProcessor stringProcessor) {
+    private static String processAndSort(String in, ToStringFunction<String> stringProcessor) {
 
-        in = stringProcessor.process(in);
+        in = stringProcessor.apply(in);
         String[] wordsArray = in.split("\\s+");
 
         List<String> words = Arrays.asList(wordsArray);

--- a/src/me/xdrop/fuzzywuzzy/algorithms/WeightedRatio.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/WeightedRatio.java
@@ -1,6 +1,6 @@
 package me.xdrop.fuzzywuzzy.algorithms;
 
-import me.xdrop.fuzzywuzzy.StringProcessor;
+import me.xdrop.fuzzywuzzy.ToStringFunction;
 
 import static me.xdrop.fuzzywuzzy.FuzzySearch.*;
 import static me.xdrop.fuzzywuzzy.algorithms.PrimitiveUtils.max;
@@ -16,10 +16,10 @@ public class WeightedRatio extends BasicAlgorithm  {
 
 
     @Override
-    public int apply(String s1, String s2, StringProcessor stringProcessor) {
+    public int apply(String s1, String s2, ToStringFunction<String> stringProcessor) {
 
-        s1 = stringProcessor.process(s1);
-        s2 = stringProcessor.process(s2);
+        s1 = stringProcessor.apply(s1);
+        s2 = stringProcessor.apply(s2);
 
         int len1 = s1.length();
         int len2 = s2.length();

--- a/src/me/xdrop/fuzzywuzzy/ratios/PartialRatio.java
+++ b/src/me/xdrop/fuzzywuzzy/ratios/PartialRatio.java
@@ -3,11 +3,11 @@ package me.xdrop.fuzzywuzzy.ratios;
 import me.xdrop.diffutils.DiffUtils;
 import me.xdrop.diffutils.structs.MatchingBlock;
 import me.xdrop.fuzzywuzzy.Ratio;
-import me.xdrop.fuzzywuzzy.StringProcessor;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import me.xdrop.fuzzywuzzy.ToStringFunction;
 
 /**
  * Partial ratio of similarity
@@ -69,8 +69,8 @@ public class PartialRatio implements Ratio {
     }
 
     @Override
-    public int apply(String s1, String s2, StringProcessor sp) {
-        return apply(sp.process(s1), sp.process(s2));
+    public int apply(String s1, String s2, ToStringFunction<String> sp) {
+        return apply(sp.apply(s1), sp.apply(s2));
     }
 
 

--- a/src/me/xdrop/fuzzywuzzy/ratios/SimpleRatio.java
+++ b/src/me/xdrop/fuzzywuzzy/ratios/SimpleRatio.java
@@ -2,7 +2,7 @@ package me.xdrop.fuzzywuzzy.ratios;
 
 import me.xdrop.diffutils.DiffUtils;
 import me.xdrop.fuzzywuzzy.Ratio;
-import me.xdrop.fuzzywuzzy.StringProcessor;
+import me.xdrop.fuzzywuzzy.ToStringFunction;
 
 public class SimpleRatio implements Ratio {
 
@@ -21,7 +21,7 @@ public class SimpleRatio implements Ratio {
     }
 
     @Override
-    public int apply(String s1, String s2, StringProcessor sp) {
-        return apply(sp.process(s1), sp.process(s2));
+    public int apply(String s1, String s2, ToStringFunction<String> sp) {
+        return apply(sp.apply(s1), sp.apply(s2));
     }
 }

--- a/test/me/xdrop/fuzzywuzzy/algorithms/DefaultStringProcessorTest.groovy
+++ b/test/me/xdrop/fuzzywuzzy/algorithms/DefaultStringProcessorTest.groovy
@@ -6,7 +6,7 @@ class DefaultStringProcessorTest extends GroovyTestCase {
 
         def inp = "s.trim μεγιουνικουντ n/o/n a.lph.a n.um"
 
-        assertEquals "s trim μεγιουνικουντ n o n a lph a n um", new DefaultStringProcessor().process(inp)
+        assertEquals "s trim μεγιουνικουντ n o n a lph a n um", new DefaultStringFunction().apply(inp)
 
     }
 

--- a/test/me/xdrop/fuzzywuzzy/algorithms/TokenSetTest.groovy
+++ b/test/me/xdrop/fuzzywuzzy/algorithms/TokenSetTest.groovy
@@ -1,13 +1,11 @@
 package me.xdrop.fuzzywuzzy.algorithms
 
-import me.xdrop.fuzzywuzzy.StringProcessor
 import me.xdrop.fuzzywuzzy.Ratio
+import me.xdrop.fuzzywuzzy.ToStringFunction
 import me.xdrop.fuzzywuzzy.ratios.PartialRatio
 
 import static org.easymock.EasyMock.anyObject
 import static org.easymock.EasyMock.eq
-import static org.easymock.EasyMock.eq
-import static org.easymock.EasyMock.expect
 import static org.easymock.EasyMock.expect
 import static org.easymock.EasyMock.mock
 import static org.easymock.EasyMock.replay
@@ -17,12 +15,12 @@ class TokenSetTest extends GroovyTestCase {
     void testUsesStringProcessor() {
         def ts = new TokenSet()
 
-        def mock = mock(StringProcessor)
+        ToStringFunction<String> mock = mock(ToStringFunction)
 
-        expect(mock.process(eq("notthesame")))
+        expect(mock.apply(eq("notthesame")))
                 .andReturn("thesame")
 
-        expect(mock.process(eq("thesame")))
+        expect(mock.apply(eq("thesame")))
                 .andReturn("thesame")
 
         replay(mock)

--- a/test/me/xdrop/fuzzywuzzy/algorithms/TokenSortTest.groovy
+++ b/test/me/xdrop/fuzzywuzzy/algorithms/TokenSortTest.groovy
@@ -1,7 +1,7 @@
 package me.xdrop.fuzzywuzzy.algorithms
 
-import me.xdrop.fuzzywuzzy.StringProcessor
 import me.xdrop.fuzzywuzzy.Ratio
+import me.xdrop.fuzzywuzzy.ToStringFunction
 import me.xdrop.fuzzywuzzy.ratios.PartialRatio
 import me.xdrop.fuzzywuzzy.ratios.SimpleRatio
 
@@ -17,12 +17,12 @@ class TokenSortTest extends GroovyTestCase {
 
         def ts = new TokenSort()
 
-        def mock = mock(StringProcessor)
+        ToStringFunction<String> mock = mock(ToStringFunction)
 
-        expect(mock.process(eq("notthesame")))
+        expect(mock.apply(eq("notthesame")))
                 .andReturn("thesame")
 
-        expect(mock.process(eq("thesame")))
+        expect(mock.apply(eq("thesame")))
                 .andReturn("thesame")
 
         replay(mock)

--- a/test/me/xdrop/fuzzywuzzy/algorithms/WeightedRatioTest.groovy
+++ b/test/me/xdrop/fuzzywuzzy/algorithms/WeightedRatioTest.groovy
@@ -1,6 +1,6 @@
 package me.xdrop.fuzzywuzzy.algorithms
 
-import me.xdrop.fuzzywuzzy.StringProcessor
+import me.xdrop.fuzzywuzzy.ToStringFunction
 
 import static org.easymock.EasyMock.*;
 
@@ -9,12 +9,12 @@ class WeightedRatioTest extends GroovyTestCase {
     void testUsesStringProcessor() {
         def wr = new WeightedRatio()
 
-        def mock = mock(StringProcessor)
+        ToStringFunction<String> mock = mock(ToStringFunction)
 
-        expect(mock.process(eq("notthesame")))
+        expect(mock.apply(eq("notthesame")))
             .andReturn("thesame")
 
-        expect(mock.process(eq("thesame")))
+        expect(mock.apply(eq("thesame")))
                 .andReturn("thesame")
 
         replay(mock)


### PR DESCRIPTION
Deprecated `StringProcessor` and replaced all occurrences with `ToStringFunction<String>`, which was implemented with 1.2.0, because it is basically a more ""primitive"" implementation and theoretically a duplicate. 
`StringProcessor` is now an abstract class, because the JDK 1.7 does not allow default methods in interfaces, which would have been required for backwards compatibility. That way, `StringProcessor` can implement `ToStringFunction<String>` and override `apply(T)` to overload `process(String)`.

`NoProcess` got deprecated and replaced with `ToStringFunction.DEFAULT`
`DefaultStringProcessor` got deprecated so that people switch to the properly named `DefaultStringFunction`