### PR TITLE
Add Android Module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: java
 sudo: false
 
-jdk:
-  - openjdk8
+jdk: oraclejdk8
 
 script:
   - ./gradlew clean test

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/FuzzyBinding.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/FuzzyBinding.java
@@ -1,0 +1,10 @@
+package me.xdrop.fuzzywuzzy.android;
+
+import me.xdrop.fuzzywuzzy.android.event.ResultsChangeEvent;
+import me.xdrop.fuzzywuzzy.android.listener.GenericListener;
+import me.xdrop.fuzzywuzzy.android.listener.ListenerManager;
+
+public interface FuzzyBinding<T> {
+    ListenerManager<GenericListener<ResultsChangeEvent<T>>> addResultsChangeListener(
+            GenericListener<ResultsChangeEvent<T>> listener);
+}

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/FuzzyDroid.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/FuzzyDroid.java
@@ -1,0 +1,14 @@
+package me.xdrop.fuzzywuzzy.android;
+
+import android.widget.TextView;
+import java.util.Collection;
+import me.xdrop.fuzzywuzzy.android.bindings.TextViewFuzzyBinding;
+import me.xdrop.fuzzywuzzy.functions.ResultProvider;
+
+public class FuzzyDroid {
+    public static <T> FuzzyBinding<T> attachFuzzy(TextView view,
+                                                  Collection<T> options,
+                                                  ResultProvider<T> resultProvider) {
+        return new TextViewFuzzyBinding<>(view, resultProvider, options);
+    }
+}

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/bindings/TextViewFuzzyBinding.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/bindings/TextViewFuzzyBinding.java
@@ -1,0 +1,105 @@
+package me.xdrop.fuzzywuzzy.android.bindings;
+
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.widget.TextView;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import me.xdrop.fuzzywuzzy.android.FuzzyBinding;
+import me.xdrop.fuzzywuzzy.android.event.ResultsChangeEvent;
+import me.xdrop.fuzzywuzzy.android.listener.GenericListener;
+import me.xdrop.fuzzywuzzy.android.listener.ListenerManager;
+import me.xdrop.fuzzywuzzy.functions.ResultProvider;
+import me.xdrop.fuzzywuzzy.model.Result;
+
+public class TextViewFuzzyBinding<T> implements FuzzyBinding<T> {
+    private final List<ListenerManager<GenericListener<ResultsChangeEvent<T>>>> listenerManagers;
+    private final TextView textView;
+    private final ResultProvider<T> resultProvider;
+    private final Collection<T> options;
+    private List<Result<T>> prevResults;
+
+    public TextViewFuzzyBinding(TextView textView, final ResultProvider<T> resultProvider, final Collection<T> options) {
+        this.textView = textView;
+        this.resultProvider = resultProvider;
+        this.options = options;
+        this.listenerManagers = new ArrayList<>();
+
+        textView.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                // ignore this callback
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                boolean call = false;
+                List<Result<T>> results = resultProvider.fetch(s.toString(), options);
+                int matches = 0;
+                // because we are in a listener thread, this will not hurt too bad
+                if (results.size() == prevResults.size()) {
+                    for (int i = 0; i < results.size(); i++) {
+                        Result<T> newRes = results.get(i);
+                        Result<T> oldRes = prevResults.get(i);
+                        if (!newRes.getString().equals(oldRes.getString())) call = true;
+                        if (call) break;
+                    }
+                } else call = true;
+                if (call) {
+                    prevResults = results;
+                    callListeners();
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                // ignore this callback
+            }
+        });
+    }
+
+    @Override
+    public ListenerManager<GenericListener<ResultsChangeEvent<T>>> addResultsChangeListener(GenericListener<ResultsChangeEvent<T>> listener) {
+        ResultsListenerManager manager = new ResultsListenerManager(listener);
+        listenerManagers.add(manager);
+        return manager;
+    }
+
+    private void callListeners() {
+        ResultsChangeEvent<T> event = new ResultsChangeEvent<>(prevResults);
+        for (ListenerManager<GenericListener<ResultsChangeEvent<T>>> listenerManager : listenerManagers)
+            listenerManager.getListener().onEvent(event);
+    }
+
+    private class ResultsListenerManager implements ListenerManager<GenericListener<ResultsChangeEvent<T>>> {
+        private final GenericListener<ResultsChangeEvent<T>> listener;
+
+        public ResultsListenerManager(GenericListener<ResultsChangeEvent<T>> listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public boolean detachNow() {
+            return listenerManagers.remove(this);
+        }
+
+        @Override
+        public ScheduledFuture<?> detachIn(long time, TimeUnit unit) {
+            return Executors.newSingleThreadScheduledExecutor().schedule(new Runnable() {
+                @Override
+                public void run() {
+                    listenerManagers.remove(ResultsListenerManager.this);
+                }
+            }, time, unit);
+        }
+
+        @Override
+        public GenericListener<ResultsChangeEvent<T>> getListener() {
+            return listener;
+        }
+    }
+}

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/event/Event.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/event/Event.java
@@ -1,0 +1,13 @@
+package me.xdrop.fuzzywuzzy.android.event;
+
+public abstract class Event {
+    private final String cause;
+
+    public Event(String cause) {
+        this.cause = cause;
+    }
+
+    public String getCause() {
+        return cause;
+    }
+}

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/event/ResultsChangeEvent.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/event/ResultsChangeEvent.java
@@ -1,0 +1,17 @@
+package me.xdrop.fuzzywuzzy.android.event;
+
+import java.util.List;
+import me.xdrop.fuzzywuzzy.model.Result;
+
+public class ResultsChangeEvent<T> extends Event {
+    private final List<Result<T>> results;
+
+    public ResultsChangeEvent(List<Result<T>> results) {
+        super("Results Changed");
+        this.results = results;
+    }
+
+    public List<Result<T>> getResults() {
+        return results;
+    }
+}

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/listener/GenericListener.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/listener/GenericListener.java
@@ -1,0 +1,7 @@
+package me.xdrop.fuzzywuzzy.android.listener;
+
+import me.xdrop.fuzzywuzzy.android.event.Event;
+
+public interface GenericListener<E extends Event> {
+    void onEvent(E event);
+}

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/listener/ListenerManager.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/android/listener/ListenerManager.java
@@ -1,0 +1,12 @@
+package me.xdrop.fuzzywuzzy.android.listener;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public interface ListenerManager<L extends GenericListener<?>> {
+    boolean detachNow();
+
+    ScheduledFuture<?> detachIn(long time, TimeUnit unit);
+
+    L getListener();
+}

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/functions/ResultProvider.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/functions/ResultProvider.java
@@ -1,0 +1,27 @@
+package me.xdrop.fuzzywuzzy.functions;
+
+import java.util.Collection;
+import java.util.List;
+import me.xdrop.fuzzywuzzy.FuzzyWuzzy;
+import me.xdrop.fuzzywuzzy.android.FuzzyDroid;
+import me.xdrop.fuzzywuzzy.model.Result;
+
+/**
+ * An interface for using the {@link FuzzyDroid} functionality.
+ * A variety of predefined ResultProviders can be found in {@link ResultProviders}.
+ *
+ * @param <T> Type of the returning results.
+ * @see ResultProviders
+ */
+public interface ResultProvider<T> {
+    /**
+     * Interface method for {@linkplain FuzzyWuzzy FuzzyWuzzy-Search} methods.
+     * This method should call a method of any FuzzyWuzzy implementation.
+     *
+     * @param target  The target string.
+     * @param options The possible options.
+     * @return A list of results.
+     * @see FuzzyWuzzy
+     */
+    List<Result<T>> fetch(String target, Collection<T> options);
+}

--- a/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/functions/ResultProviders.java
+++ b/android-attacher/src/main/java/me/xdrop/fuzzywuzzy/functions/ResultProviders.java
@@ -1,0 +1,127 @@
+package me.xdrop.fuzzywuzzy.functions;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import me.xdrop.fuzzywuzzy.FuzzyWuzzy;
+import me.xdrop.fuzzywuzzy.algorithms.Algorithm;
+import me.xdrop.fuzzywuzzy.algorithms.AlgorithmFactory;
+import me.xdrop.fuzzywuzzy.model.Result;
+import me.xdrop.fuzzywuzzy.model.ScoringMethod;
+
+/**
+ * A factory for simple, predefined {@linkplain ResultProvider ResultProviders}.
+ */
+public class ResultProviders {
+    /**
+     * Creates a new ResultProvider that looks for only the best result.
+     *
+     * @param withAlgorithmFactory The algorithm to be used.
+     * @param withStringMapper     The stringMapper to be used.
+     * @param withMethod           The scoringMethod to be used.
+     * @param <T>                  Type-variable for the element type.
+     * @param <A>                  Type-variable for the algorithm.
+     * @return A new ResultProvider that only returns the best result.
+     * @see FuzzyWuzzy#extractBest(String, Collection, StringMapper, ScoringMethod)
+     */
+    public static <T, A extends Algorithm> ResultProvider<T> best(
+            final AlgorithmFactory<A> withAlgorithmFactory,
+            final StringMapper<T> withStringMapper,
+            final ScoringMethod withMethod) {
+        return new ResultProvider<T>() {
+            final FuzzyWuzzy<A> fuzzy = FuzzyWuzzy.algorithm(withAlgorithmFactory);
+            final StringMapper<T> stringMapper = Objects.requireNonNull(withStringMapper);
+            final ScoringMethod method = Objects.requireNonNull(withMethod);
+
+            @Override
+            public List<Result<T>> fetch(String target, Collection<T> options) {
+                return Collections.singletonList(fuzzy.extractBest(target, options, stringMapper, method));
+            }
+        };
+    }
+
+    /**
+     * Creates a new ResultProvider that limits the amount of results.
+     *
+     * @param withAlgorithmFactory The algorithm to be used.
+     * @param withStringMapper     The stringMapper to be used.
+     * @param withMethod           The scoringMethod to be used.
+     * @param withLimit            The maximum amount of results to return.
+     * @param <T>                  Type-variable for the element type.
+     * @param <A>                  Type-variable for the algorithm.
+     * @return A new ResultProvider.
+     * @see FuzzyWuzzy#extractLimited(String, Collection, StringMapper, ScoringMethod, int)
+     */
+    public static <T, A extends Algorithm> ResultProvider<T> limited(
+            final AlgorithmFactory<A> withAlgorithmFactory,
+            final StringMapper<T> withStringMapper,
+            final ScoringMethod withMethod,
+            final int withLimit) {
+        return new ResultProvider<T>() {
+            final FuzzyWuzzy<A> fuzzy = FuzzyWuzzy.algorithm(withAlgorithmFactory);
+            final StringMapper<T> stringMapper = Objects.requireNonNull(withStringMapper);
+            final ScoringMethod method = Objects.requireNonNull(withMethod);
+            final int limit = withLimit;
+
+            @Override
+            public List<Result<T>> fetch(String target, Collection<T> options) {
+                return fuzzy.extractLimited(target, options, stringMapper, method, limit);
+            }
+        };
+    }
+
+    /**
+     * Creates a new ResultProvider that sorts the output.
+     *
+     * @param withAlgorithmFactory The algorithm to be used.
+     * @param withStringMapper     The stringMapper to be used.
+     * @param withMethod           The scoringMethod to be used.
+     * @param <T>                  Type-variable for the element type.
+     * @param <A>                  Type-variable for the algorithm.
+     * @return A new ResultProvider.
+     * @see FuzzyWuzzy#extractAllSorted(String, Collection, StringMapper, ScoringMethod)
+     */
+    public static <T, A extends Algorithm> ResultProvider<T> sorted(
+            final AlgorithmFactory<A> withAlgorithmFactory,
+            final StringMapper<T> withStringMapper,
+            final ScoringMethod withMethod) {
+        return new ResultProvider<T>() {
+            final FuzzyWuzzy<A> fuzzy = FuzzyWuzzy.algorithm(withAlgorithmFactory);
+            final StringMapper<T> stringMapper = Objects.requireNonNull(withStringMapper);
+            final ScoringMethod method = Objects.requireNonNull(withMethod);
+
+            @Override
+            public List<Result<T>> fetch(String target, Collection<T> options) {
+                return fuzzy.extractAllSorted(target, options, stringMapper, method);
+            }
+        };
+    }
+
+    /**
+     * Creates a new ResultProvider that returns an untreated list of results.
+     *
+     * @param withAlgorithmFactory The algorithm to be used.
+     * @param withStringMapper     The stringMapper to be used.
+     * @param withMethod           The scoringMethod to be used.
+     * @param <T>                  Type-variable for the element type.
+     * @param <A>                  Type-variable for the algorithm.
+     * @return A new ResultProvider.
+     * @see FuzzyWuzzy#extractAll(String, Collection, StringMapper, ScoringMethod)
+     */
+    public static <T, A extends Algorithm> ResultProvider<T> all(
+            final AlgorithmFactory<A> withAlgorithmFactory,
+            final StringMapper<T> withStringMapper,
+            final ScoringMethod withMethod) {
+        return new ResultProvider<T>() {
+            final FuzzyWuzzy<A> fuzzy = FuzzyWuzzy.algorithm(withAlgorithmFactory);
+            final StringMapper<T> stringMapper = Objects.requireNonNull(withStringMapper);
+            final ScoringMethod method = Objects.requireNonNull(withMethod);
+
+            @Override
+            public List<Result<T>> fetch(String target, Collection<T> options) {
+                return fuzzy.extractAll(target, options, stringMapper, method);
+            }
+        };
+    }
+}

--- a/android-compat/README.md
+++ b/android-compat/README.md
@@ -1,0 +1,5 @@
+# COMPILATION MODULE
+
+This module is only included for compiling with Android SDK methods, as there is no provided library to acquire Android dependencies.
+
+All classes within this module are abstract and only contain abstract methods.

--- a/android-compat/src/android/text/Editable.java
+++ b/android-compat/src/android/text/Editable.java
@@ -1,0 +1,4 @@
+package android.text;
+
+public abstract class Editable {
+}

--- a/android-compat/src/android/text/TextWatcher.java
+++ b/android-compat/src/android/text/TextWatcher.java
@@ -1,0 +1,9 @@
+package android.text;
+
+public abstract class TextWatcher {
+    public abstract void beforeTextChanged(CharSequence s, int start, int count, int after);
+
+    public abstract void onTextChanged(CharSequence s, int start, int before, int count);
+
+    public abstract void afterTextChanged(Editable s);
+}

--- a/android-compat/src/android/widget/TextView.java
+++ b/android-compat/src/android/widget/TextView.java
@@ -1,0 +1,7 @@
+package android.widget;
+
+import android.text.TextWatcher;
+
+public abstract class TextView {
+    public abstract void addTextChangedListener(TextWatcher textWatcher);
+}

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,28 @@ project(':levenshtein') {
     }
 }
 
+project(':android-attacher') {
+    version '0.1.0'
+    
+    repositories {
+        google()
+    }
+    
+    dependencies {
+        implementation project(':fuzzywuzzy')
+        implementation 'com.android.support:appcompat-v7:28.0.0'
+        implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+        
+        println "[INFO] Resolving dependencies of module ${project.name} cannot be finished automatically; " +
+                "you need to set up Android SDK 28 manually as module SDK within your IDE."
+    }
+    
+    test {
+        // DO NOT run tests on Travis because this module additionally requires Android SDK 28 or higher.
+        if (isTravis()) outputs.upToDateWhen { true }
+    }
+}
+
 // utility method to decide whether we are on travis ci machine
 static boolean isTravis() {
     return System.getenv().containsKey("TRAVIS")

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,6 @@ project.version = '2.0.0'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-// if we are not on travis, use the publishing file
-if (!isTravis()) {
-    apply from: 'gradle/publishing.gradle'
-}
-
 task wrapper(type: Wrapper) {
     gradleVersion = '4.10.2'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
@@ -90,17 +85,33 @@ project(':android-attacher') {
     
     dependencies {
         implementation project(':fuzzywuzzy')
-        implementation 'com.android.support:appcompat-v7:28.0.0'
-        implementation 'com.android.support.constraint:constraint-layout:1.1.3'
         
+        // Workaround dependency for compiling with android methods baked in
+        compileOnly project(':android-compat')
+
         println "[INFO] Resolving dependencies of module ${project.name} cannot be finished automatically; " +
                 "you need to set up Android SDK 28 manually as module SDK within your IDE."
     }
     
     test {
         // DO NOT run tests on Travis because this module additionally requires Android SDK 28 or higher.
-        if (isTravis()) outputs.upToDateWhen { true }
+        outputs.upToDateWhen { true }
     }
+}
+
+project(':android-compat') {
+    sourceSets {
+        main {
+            java {
+                srcDirs = ["src\\"]
+            }
+        }
+    }
+}
+
+// if we are not on travis, use the publishing file
+if (!isTravis()) {
+    apply from: 'gradle/publishing.gradle'
 }
 
 // utility method to decide whether we are on travis ci machine

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -36,7 +36,8 @@ publishing {
                 void accept(Object o1, Object o2) {
                     final String name = (String) o1
                     final Project proj = (Project) o2
-                    gradle.rootProject.publishing.publications.mavenJava.artifact proj.jar
+                    if (!name.toLowerCase().contains("compat")) // if not a compat module
+                        gradle.rootProject.publishing.publications.mavenJava.artifact proj.jar
                 }
             })
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,5 +5,8 @@ include ':fuzzywuzzy'
 
 // Levenshtein algorithm module
 include ':levenshtein'
+
 // Android attach module
 include ':android-attacher'
+// Android compatibility module for compiling android-attacher module using gradle
+include ':android-compat'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,3 +5,5 @@ include ':fuzzywuzzy'
 
 // Levenshtein algorithm module
 include ':levenshtein'
+// Android attach module
+include ':android-attacher'


### PR DESCRIPTION
Closes https://github.com/xdrop/fuzzywuzzy/issues/64

Adds a module that uses Android SDK to provide a simple way to attach a FuzzyWuzzy engine to a TextInput object within an Android app.