### PR TITLE
Use an equal check on the referent rather than on the string

### DIFF
--- a/fuzzywuzzy/src/main/java/me/xdrop/fuzzywuzzy/model/Result.java
+++ b/fuzzywuzzy/src/main/java/me/xdrop/fuzzywuzzy/model/Result.java
@@ -89,7 +89,7 @@ public class Result<T> implements Comparable<Result<T>> {
     public boolean equals(Object other) {
         if (!(other instanceof Result)) return false;
         final Result res = (Result) other;
-        return res.isStringReferent == isStringReferent && res.string.equals(string);
+        return res.isStringReferent == isStringReferent && res.referent.equals(referent);
     }
 
     @Override


### PR DESCRIPTION
This can come in handy in a case where the user has implemented a custom equals implementation that may return TRUE even if the resulting string is not the same, and it seems more logical to rather check the actual referent instead of the string representation.
Note that this check will never occur if not this and the to-be-compared-Result are not both on the same string referent state. (&& ends if left statement is false already)