### PR TITLE
Add Automatic-Module-Name on fatjar to provide Java 9 module support.

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -152,6 +152,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>me.xdrop.fuzzywuzzy</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
                 <configuration>


### PR DESCRIPTION
This should provide the ability to use this package with Java 9 modules.

Currently, builds under Java 9 or newer that rely on modules will flag the following warning:

```
[INFO] --- maven-compiler-plugin:3.8.1:compile (java-compile) @ katana-compiler-testing ---
[WARNING] ********************************************************************************************************************************************
[WARNING] * Required filename-based automodules detected: [fuzzywuzzy-1.3.1.jar]. Please don't publish this project to a public artifact repository! *
[WARNING] ********************************************************************************************************************************************
```

Worth noting that the tests are not running for me:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running me.xdrop.diffutils.DiffUtilsTest
Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.264 sec <<< FAILURE!
testGetRatio(me.xdrop.diffutils.DiffUtilsTest)  Time elapsed: 0.063 sec  <<< ERROR!
groovy.lang.MissingMethodException: No signature of method: java.util.Random.nextInt() is applicable for argument types: (java.lang.Integer) values: [200]
Possible solutions: getAt(java.lang.String)
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:58)
        at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:49)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
        at me.xdrop.diffutils.DiffUtilsTest.testGetRatio(DiffUtilsTest.groovy:32)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at junit.framework.TestCase.runTest(TestCase.java:176)
        at junit.framework.TestCase.runBare(TestCase.java:141)
        at junit.framework.TestResult$1.protect(TestResult.java:122)
        at junit.framework.TestResult.runProtected(TestResult.java:142)
        at junit.framework.TestResult.run(TestResult.java:125)
        at junit.framework.TestCase.run(TestCase.java:129)
        at junit.framework.TestSuite.runTest(TestSuite.java:252)
        at junit.framework.TestSuite.run(TestSuite.java:247)
        at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:86)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
        at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
        at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)


Results :

Tests in error: 
  testGetRatio(me.xdrop.diffutils.DiffUtilsTest): No signature of method: java.util.Random.nextInt() is applicable for argument types: (java.lang.Integer) values: [200](..)

Tests run: 2, Failures: 0, Errors: 1, Skipped: 0
```

...however this appears to be out of scope of this specific change, so I have left this as-is for now.