### PR TITLE
Amend version info and add JPMS info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Maven Central](https://img.shields.io/maven-central/v/me.xdrop/fuzzywuzzy?logo=apache-maven&style=flat-square)](https://search.maven.org/artifact/me.xdrop/fuzzywuzzy)
+
 # JavaWuzzy
 
 ## FuzzyWuzzy Java Implementation
@@ -16,28 +18,46 @@ this in Java. Enjoy!
 
 
 ## Installation
+
+In Maven and Gradle examples, remember to replace "`VERSION`" with the 
+[latest release](https://search.maven.org/artifact/me.xdrop/fuzzywuzzy) of this
+library.
+
 ### Maven Central
 ```xml
 <dependency>
     <groupId>me.xdrop</groupId>
     <artifactId>fuzzywuzzy</artifactId>
-    <version>1.3.1</version>
+    <version>VERSION</version>
 </dependency>
 ```
 
 ### Gradle
 ```gradle
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'me.xdrop:fuzzywuzzy:1.3.1'
+    implementation 'me.xdrop:fuzzywuzzy:VERSION'
+}
+```
+
+### JPMS 
+
+If you use Java 9 or newer, and use the Java Platform Module System (JPMS), you will need to add
+the following declarations to your `module-info.java` file:
+
+```java
+module my.modulename.here {
+    requires java.base;
+    requires me.xdrop.fuzzywuzzy;
 }
 ```
 
 ### Jar release
-Download the latest release [here](https://github.com/xdrop/fuzzywuzzy/releases) and add to your classpath
+
+Download the latest release [here](https://github.com/xdrop/fuzzywuzzy/releases) and add to your classpath.
 
 ## Usage
 


### PR DESCRIPTION
Thanks for releasing 1.3.3, that solved the Java 9 issues that I was having perfectly!
In response to that, I've put forward a couple of updates to the README.md to be 
in line with that update!

- Add badge to direct to Maven Central and to display the most recent version
  so that it does not need to be updated each time.
- Replace hard-coded versions in examples with placeholder, as the reader can
  now use the Maven Central links or just refer to the badge to get the newest
  version.
- Add JPMS info for Java 9 modules to README.
- Replace `jcenter()` with `mavenCentral()` in README, since the project is on
  Maven Central and JCenter is being shut down
  (see https://blog.gradle.org/jcenter-shutdown for discussions of impacts on Gradle 
  builds).