### PR TITLE
add similarity sort algorithm

### DIFF
--- a/src/me/xdrop/fuzzywuzzy/algorithms/Utils.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/Utils.java
@@ -1,5 +1,7 @@
 package me.xdrop.fuzzywuzzy.algorithms;
 
+import me.xdrop.fuzzywuzzy.FuzzySearch;
+
 import java.util.*;
 
 final public class Utils {
@@ -23,6 +25,32 @@ final public class Utils {
 
         return join(col, sep);
 
+    }
+
+    //sort tokens2 with reference to tokens1
+    static String similaritySortAndJoin(String[] tokens1, String[] tokens2, String sep) {
+        for (int i = 0; i < tokens1.length; i++) {
+            final int[] distances = new int[tokens2.length];
+
+            for (int j = i; j < tokens2.length; j++) {
+                distances[j] = FuzzySearch.ratio(tokens1[i], tokens2[j]);
+            }
+            //find max match token
+            int max = 0, maxpos = 0;
+
+            for (int a = i; a < distances.length; a++) {
+                if (distances[a] > max) {
+                    maxpos = a;
+                    max = distances[a];
+                }
+            }
+            //swap
+            final String tmp = tokens2[maxpos];
+            tokens2[maxpos] = tokens2[i];
+            tokens2[i] = tmp;
+        }
+        //join
+        return join(Arrays.asList(tokens2), sep);
     }
 
     static String join(List<String> strings, String sep) {


### PR DESCRIPTION
The current sort algorithm used to sort the tokenised strings is alphabetical sort. This has shortcomings such as when two similar words begin with different letters.
I propose the addition of Levenstein sort on the tokens themselves to improve the accuracy in such instances.