### PR TITLE
Fix space adding related bug in algorithm/Utils.java

### DIFF
--- a/src/me/xdrop/fuzzywuzzy/algorithms/Utils.java
+++ b/src/me/xdrop/fuzzywuzzy/algorithms/Utils.java
@@ -29,16 +29,13 @@ final public class Utils {
         final StringBuilder buf = new StringBuilder(strings.size() * 16);
 
         for(int i = 0; i < strings.size(); i++){
-
-            if(i < strings.size()) {
+            buf.append(strings.get(i));
+            if(i < strings.size() - 1) {
                 buf.append(sep);
             }
-
-            buf.append(strings.get(i));
-
         }
 
-        return buf.toString().trim();
+        return buf.toString();
     }
 
     static String sortAndJoin(Set<String> col, String sep){


### PR DESCRIPTION
In current code, spaces are being added before the strings and the `i < strings.size()` check has no affect. Although before returning, the final string is being trimmed. We can fix the space addition bug and avoid the trim.

Also one more bug is, if the `sep` parameter is not `space`, then the `trim()` method won't remove the the separator from the beginning of the final string: `sep + strings[0] + sep + strings[1] + sep + ..... + sep + strings[n - 1]`. This PR fixes that too.